### PR TITLE
Point web app to online Supabase instead of local Supabase

### DIFF
--- a/src-mobile-app/.gitignore
+++ b/src-mobile-app/.gitignore
@@ -33,3 +33,5 @@ yarn-error.*
 
 # typescript
 *.tsbuildinfo
+
+expo-env.d.ts

--- a/src-web-app/src/hooks.server.ts
+++ b/src-web-app/src/hooks.server.ts
@@ -1,14 +1,13 @@
-import { PUBLIC_SUPABASE_URL, PUBLIC_SUPABASE_ANON_KEY, PUBLIC_DEV_SUPABASE_URL, PUBLIC_DEV_SUPABASE_ANON_KEY } from '$env/static/public';
+import { PUBLIC_SUPABASE_URL, PUBLIC_SUPABASE_ANON_KEY } from '$env/static/public';
 import { createServerClient } from '@supabase/ssr';
 import { error, redirect, type Handle } from '@sveltejs/kit';
 import { sequence } from '@sveltejs/kit/hooks';
-import { dev } from '$app/environment';
 
 // Supabase init function for server
 const supabase: Handle = async function ({ event, resolve }) {
   event.locals.supabase = createServerClient(
-    dev ? PUBLIC_DEV_SUPABASE_URL : PUBLIC_SUPABASE_URL,
-    dev ? PUBLIC_DEV_SUPABASE_ANON_KEY : PUBLIC_SUPABASE_ANON_KEY,
+    PUBLIC_SUPABASE_URL,
+    PUBLIC_SUPABASE_ANON_KEY,
     {
       cookies: {
         get: (key) => event.cookies.get(key),

--- a/src-web-app/src/routes/+layout.ts
+++ b/src-web-app/src/routes/+layout.ts
@@ -1,5 +1,4 @@
-import { dev } from '$app/environment';
-import { PUBLIC_SUPABASE_URL, PUBLIC_SUPABASE_ANON_KEY, PUBLIC_DEV_SUPABASE_ANON_KEY, PUBLIC_DEV_SUPABASE_URL } from '$env/static/public';
+import { PUBLIC_SUPABASE_URL, PUBLIC_SUPABASE_ANON_KEY } from '$env/static/public';
 import type { LayoutLoad } from './$types';
 import { combineChunks, createBrowserClient, isBrowser, parse } from '@supabase/ssr';
 
@@ -7,8 +6,8 @@ export const load: LayoutLoad = async ({ url, fetch, data, depends }) => {
   depends('supabase:auth');
 
   const supabase = createBrowserClient(
-    dev ? PUBLIC_DEV_SUPABASE_URL : PUBLIC_SUPABASE_URL,
-    dev ? PUBLIC_DEV_SUPABASE_ANON_KEY : PUBLIC_SUPABASE_ANON_KEY,
+    PUBLIC_SUPABASE_URL,
+    PUBLIC_SUPABASE_ANON_KEY,
     {
       global: {
         fetch


### PR DESCRIPTION
Related to #32 

In an effort to simplify development, the web app will point to the online Supabase instance instead of the local one.
This also means that the mobile app and web app will share the same database / auth.