### PR TITLE
Display event banners, use fallbacks

### DIFF
--- a/src-mobile-app/src/app/(tabs)/events/[id].tsx
+++ b/src-mobile-app/src/app/(tabs)/events/[id].tsx
@@ -1,4 +1,4 @@
-import React from "react";
+import React, { useState } from "react";
 import { useAuth } from "../../../features/system/Auth";
 import { useAssets } from "expo-asset";
 import { useLocalSearchParams, Stack } from "expo-router";
@@ -8,6 +8,7 @@ import { SBEvent, SBTeamStats } from "../../../lib/supabase-types";
 import { useTypedDispatch, useTypedSelector } from "../../../store/store";
 import { Text as RN_Text } from "react-native";
 import { setActiveEvent } from "../../../store/eventsSlice";
+import { supabase } from "../../../lib/supabase";
 
 export default function EventDetails() {
   const theme = useTheme();
@@ -25,8 +26,12 @@ export default function EventDetails() {
 
   const [assets] = useAssets([
     require('../../../../assets/images/preview_square.jpg'),
-    require('../../../../assets/images/preview_wide.jpg')
+    require('../../../../assets/images/preview_wide.jpg'),
+    // Event banner (if exists) in the public event assets bucket
+    supabase.storage.from('EventAssets').getPublicUrl(`Banners/${slugEventID}`).data.publicUrl
   ]);
+
+  const [useFallback, setUseFallback] = useState(false);
 
   const registerCallback = React.useCallback(() => {
     dispatch(setActiveEvent(event));
@@ -54,7 +59,12 @@ export default function EventDetails() {
             width={'100%'}
             height={'100%'}
             resizeMode="stretch"
-            source={{ uri: assets[1].uri, width: assets[1].width!, height: assets[1].height! }}
+            source={{
+              uri: useFallback ? assets[1].uri : assets[2].uri,
+              width: useFallback ? assets[1].width! : assets[2].width!,
+              height: useFallback ? assets[1].height! : assets[2].height!
+            }}
+            onError={() => setUseFallback(true)}
             />
         </YStack>
 

--- a/src-mobile-app/src/features/events/EventCard.tsx
+++ b/src-mobile-app/src/features/events/EventCard.tsx
@@ -2,8 +2,9 @@ import { AnimatePresence, Card, H3, Image, Text, XStack, YStack } from "tamagui"
 import { Tables } from "../../lib/supabase-types";
 import { useAssets } from "expo-asset";
 import { LinearGradient } from 'tamagui/linear-gradient'
-import React from "react";
+import React, { useEffect, useState } from "react";
 import { router } from "expo-router";
+import { supabase } from "../../lib/supabase";
 
 type Props = {
   event: Tables<'Events'>
@@ -12,8 +13,13 @@ type Props = {
 export default function EventCard({ event }: Props) {
   const [assets] = useAssets([
     require('../../../assets/images/preview_square.jpg'),
-    require('../../../assets/images/preview_wide.jpg')
+    require('../../../assets/images/preview_wide.jpg'),
+    // Event banner (if exists) in the public event assets bucket
+    supabase.storage.from('EventAssets').getPublicUrl(`Banners/${event.EventID}`).data.publicUrl
   ]);
+
+  // Display the fallback image if the event banner is not available
+  const [useFallback, setUseFallback] = useState(false);
 
   function getDateString() {
     const starts = new Date(event.StartsAt).getTime();
@@ -47,7 +53,12 @@ export default function EventCard({ event }: Props) {
                 height={'100%'}
                 marginLeft={-1}
                 resizeMode="stretch"
-                source={{ uri: assets[1].uri, width: assets[1].width!, height: assets[1].height! }}
+                source={{
+                  uri: useFallback ? assets[1].uri : assets[2].uri,
+                  width: useFallback ? assets[1].width! : assets[2].width!,
+                  height: useFallback ? assets[1].height! : assets[2].height!
+                }}
+                onError={() => setUseFallback(true)}
                 />
             </YStack>
           )}


### PR DESCRIPTION
Related to #97. The mobile app will display an event banner if exists, otherwise use our generic fallback image.