### PR TITLE
Fix broken link

### DIFF
--- a/src-web-app/src/routes/about/Divider.svelte
+++ b/src-web-app/src/routes/about/Divider.svelte
@@ -6,7 +6,7 @@
 <div class="flex w-full">
     <div class="grid h-20 card place-items-center">
         <div class="w-auto flex flex-row items-center my-8 mt-4">
-            <a href="https://github.com/OregonStateUniversity/osu-fs" target="_blank" class="text-2xl mr-4 link link-hover">OSU FSF on Github</a>
+            <a href="https://github.com/OregonStateUniversity/osu-fsf" target="_blank" class="text-2xl mr-4 link link-hover">OSU FSF on Github</a>
             <a href="https://github.com/OregonStateUniversity/osu-fsf" target="_blank">
               <SVGComponents svgLabel="github-logo" width="49" height="48" />
             </a>


### PR DESCRIPTION
The GitHub repo link was broken on the `/about` route, this PR fixes that.