### PR TITLE
[WEB] Adding upcoming events UI

### DIFF
--- a/src-web-app/src/routes/events/+page.svelte
+++ b/src-web-app/src/routes/events/+page.svelte
@@ -146,22 +146,26 @@
       </div>
 
       <!-- Container for UPCOMING events -->
-      <!-- <div class="flex ml-4 flex-col custom-border h-fit w-[50%] pt-3">
+      <div class="flex ml-4 flex-col custom-border h-fit w-[50%] pt-3">
         <div class="flex flex-row w-[100%] pb-4">
           <p class="inline-block" style="font-size: 18px; font-weight:628;">Upcoming Events</p>
           <a href="/events/category/Upcoming" style="margin-left: 10px;">
             <button class="btn btn-xs font-normal font-sans bg-light-black hover:bg-light-blackSelected text-white rounded-full">View All</button>
           </a>
         </div>
-        <Card
-          Name={relevantEvents.upcomingEvent?.Name}
-          StartsAt={relevantEvents.upcomingEvent?.StartsAt}
-          EndsAt={relevantEvents.upcomingEvent?.EndsAt}
-          Description={relevantEvents?.upcomingEvent?.Description}
-          EventID={relevantEvents.upcomingEvent?.EventID}
-          BannerURL={relevantEvents.upcomingEvent?.BannerURL}
-        />
-      </div> -->
+        {#if upcomingEvents.length > 0}
+          <Card
+            Name={relevantEvents.upcomingEvent?.Name}
+            StartsAt={relevantEvents.upcomingEvent?.StartsAt}
+            EndsAt={relevantEvents.upcomingEvent?.EndsAt}
+            Description={relevantEvents?.upcomingEvent?.Description}
+            EventID={relevantEvents.upcomingEvent?.EventID}
+            BannerURL={relevantEvents.upcomingEvent?.BannerURL}
+          />
+        {:else}
+          <p>No upcoming events</p>
+        {/if}
+      </div>
     </div>
   {/if}
 </Layout>


### PR DESCRIPTION
### Issue:
https://vinle538.atlassian.net/browse/SCRUM-54

### What this change does: 
This change adds UI for the upcoming events on the /events page. 

### Why do we need this change:
We need this change so the user can see upcoming events.

### Result:
<img width="1118" alt="Screenshot 2025-01-09 at 1 18 42 PM" src="https://github.com/user-attachments/assets/22051e3f-c4ef-468f-bff1-927888564d7f" />

<img width="1149" alt="Screenshot 2025-01-09 at 1 18 57 PM" src="https://github.com/user-attachments/assets/a2229344-0656-4bbe-8aa0-c2736f62d0d5" />
