### PR TITLE
Changed name of column to match event creation page

### DIFF
--- a/supabase/migrations/20250122025807_achievements-changes.sql
+++ b/supabase/migrations/20250122025807_achievements-changes.sql
@@ -2,4 +2,4 @@ ALTER TABLE "public"."Events"
 ADD COLUMN "AchievementCount" text;
 
 ALTER TABLE "public"."Events" 
-ADD COLUMN "Tiers" text[];
+ADD COLUMN "Achievements" text[];


### PR DESCRIPTION
Changed Events column from 'Tiers' to 'Achievements'. The event creation page on the web app was using the name 'Achievements' for the achievement tiers, so I had to change it to match.